### PR TITLE
Surface RPC errors to client caller

### DIFF
--- a/kwamp-client-app/src/main/kotlin/nz/co/arm/kwamp/client/app/App.kt
+++ b/kwamp-client-app/src/main/kotlin/nz/co/arm/kwamp/client/app/App.kt
@@ -1,5 +1,6 @@
 package nz.co.arm.kwamp.client.app
 
+import co.nz.arm.kwamp.core.Uri
 import co.nz.arm.kwamp.core.WAMP_DEFAULT
 import co.nz.arm.kwamp.core.WAMP_JSON
 import co.nz.arm.kwamp.core.WAMP_MSG_PACK
@@ -24,8 +25,9 @@ object App {
     fun main(args: Array<String>) {
         val wampClient = createWebsocketWampClient()
 
+        val call = wampClient.call(Uri("test.proc"))
         runBlocking {
-            println(wampClient.call("test.proc").await())
+            println(call.await())
         }
     }
 
@@ -33,7 +35,7 @@ object App {
         val wampIncoming = Channel<ByteArray>()
         val wampOutgoing = Channel<ByteArray>()
         establishWebsocketConnection(wampIncoming, wampOutgoing)
-        return Client(wampIncoming, wampOutgoing, realm = "default")
+        return Client(wampIncoming, wampOutgoing, realm = Uri("default"))
     }
 
     private fun establishWebsocketConnection(

--- a/kwamp-client/src/main/kotlin/nz/co/arm/kwamp/client/Caller.kt
+++ b/kwamp-client/src/main/kotlin/nz/co/arm/kwamp/client/Caller.kt
@@ -3,9 +3,7 @@ package nz.co.arm.kwamp.client
 import co.nz.arm.kwamp.core.Connection
 import co.nz.arm.kwamp.core.RandomIdGenerator
 import co.nz.arm.kwamp.core.Uri
-import co.nz.arm.kwamp.core.messages.Call
-import co.nz.arm.kwamp.core.messages.Dict
-import co.nz.arm.kwamp.core.messages.Result
+import co.nz.arm.kwamp.core.messages.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
@@ -22,7 +20,7 @@ class Caller(
         procedure: Uri,
         arguments: List<Any?>?,
         argumentsKw: Dict?
-    ): Deferred<CallResult> = sendCallMessage(procedure, arguments, argumentsKw)
+    ): DeferredCallResult = sendCallMessage(procedure, arguments, argumentsKw)
 
 
     //TODO messageSender?
@@ -35,15 +33,49 @@ class Caller(
             GlobalScope.launch {
                 connection.send(Call(requestId, emptyMap(), procedure, arguments, argumentsKw))
             }
-            CompletableDeferred<CallResult>().also {
+            DeferredCallResult(CompletableDeferred<CallResult>().also {
                 calls[requestId] = it
-            }
+            })
         }
 
 
     fun result(resultMessage: Result) {
-        calls[resultMessage.requestId]?.complete(CallResult(resultMessage.arguments, resultMessage.argumentsKw))
+        calls.remove(resultMessage.requestId)?.complete(CallResult(resultMessage.arguments, resultMessage.argumentsKw))
+            ?: throw IllegalStateException("Could find request id ${resultMessage.requestId} in calls")
+    }
+
+    fun error(errorMessage: Error) {
+        calls.remove(errorMessage.requestId)?.cancel(errorMessage.toCallException())
+            ?: throw IllegalStateException("Could find request id ${errorMessage.requestId} in calls")
     }
 }
 
+class DeferredCallResult(private val deferredResult: Deferred<CallResult>) {
+    suspend fun await() = deferredResult.await()
+    suspend fun join() = deferredResult.join()
+
+    fun invokeOnError(errorCallback: (CallError) -> Unit) {
+        deferredResult.invokeOnCompletion { throwable ->
+            (throwable as? CallError)?.apply { callbackAsynchronously(this, errorCallback) }
+        }
+    }
+
+    private fun callbackAsynchronously(error: CallError, callback: (CallError) -> Unit) =
+        GlobalScope.launch {
+            callback(error)
+        }
+}
+
 data class CallResult(val arguments: List<Any?>? = null, val argumentsKw: Dict? = null)
+
+data class CallError(val error: Uri, val details: Dict, val arguments: List<Any?>?, val argumentsKw: Dict?) :
+    Throwable(message = error.text)
+
+internal fun Error.toCallException() =
+    if (requestType == MessageType.CALL)
+        CallError(
+            error,
+            details,
+            arguments,
+            argumentsKw
+        ) else throw IllegalArgumentException("Request message type must be CALL to to convert to call exception, but got $requestType")

--- a/kwamp-core/src/main/kotlin/co/nz/arm/kwamp/core/Uri.kt
+++ b/kwamp-core/src/main/kotlin/co/nz/arm/kwamp/core/Uri.kt
@@ -8,18 +8,18 @@ import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.ToJson
 
 //TODO validate construction (S5.1.1) and return WampError.INVALID_URI on failure
-data class Uri(val uri: String) {
+data class Uri(val text: String) {
     object UriConverter : Converter {
         override fun canConvert(cls: Class<*>) = cls == Uri::class.java
         override fun fromJson(jv: JsonValue): Any = false
-        override fun toJson(value: Any) = "\"${(value as Uri).uri}\""
+        override fun toJson(value: Any) = "\"${(value as Uri).text}\""
     }
 
     object UriJsonAdapter : JsonAdapter<Uri>() {
         override fun fromJson(reader: JsonReader?): Uri? = null
         @ToJson
         override fun toJson(writer: JsonWriter?, uri: Uri?) {
-            writer!!.value(uri!!.uri)
+            writer!!.value(uri!!.text)
         }
     }
 }

--- a/kwamp-router/src/main/kotlin/co/nz/arm/kwamp/router/Realm.kt
+++ b/kwamp-router/src/main/kotlin/co/nz/arm/kwamp/router/Realm.kt
@@ -60,6 +60,7 @@ class Realm(
 
             is Error -> handleError(message)
 
+            //TODO protocol violation?
             else -> throw NotImplementedError("Message type ${message.messageType} not implemented")
         }
     }
@@ -67,6 +68,7 @@ class Realm(
     private fun handleError(errorMessage: Error) {
         when (errorMessage.requestType) {
             MessageType.INVOCATION -> dealer.handleInvocationError(errorMessage)
+            //TODO protocol violation?
             else -> throw NotImplementedError("Error with request type ${errorMessage.requestType} not implemented")
         }
     }

--- a/kwamp-router/src/main/kotlin/co/nz/arm/kwamp/router/SessionEstablisher.kt
+++ b/kwamp-router/src/main/kotlin/co/nz/arm/kwamp/router/SessionEstablisher.kt
@@ -15,7 +15,7 @@ class SessionEstablisher(
     suspend fun establish() {
         connection.withNextMessage { message: Hello ->
             realms[message.realm]?.join(connection)
-                ?: throw NoSuchRealmException("Realm '${message.realm.uri}' does not exist")
+                ?: throw NoSuchRealmException("Realm '${message.realm.text}' does not exist")
         }.invokeOnCompletion { throwable ->
             when (throwable) {
                 is ProtocolViolationException -> messageSender.sendAbort(connection, throwable)


### PR DESCRIPTION
So a user of the client library now gets an exception from the deferred result if the router sends back an ERROR for it