### PR TITLE
Implemented client procedure unregistering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 val kotlinVersion: String by extra
 val kotlinTestVersion = "3.1.10"
 val coroutinesVersion = "0.30.2-eap13"
+val logbackVersion = "1.2.1"
 
 subprojects {
     apply {
@@ -50,6 +51,7 @@ subprojects {
         implementation(kotlin("stdlib", kotlinVersion))
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
         implementation(kotlin("reflect", kotlinVersion))
+        implementation("ch.qos.logback:logback-classic:$logbackVersion")
 
         testImplementation("io.kotlintest:kotlintest-runner-junit5:$kotlinTestVersion")
     }

--- a/kwamp-client-core/src/main/kotlin/com/laurencegarmstrong/kwamp/client/core/Client.kt
+++ b/kwamp-client-core/src/main/kotlin/com/laurencegarmstrong/kwamp/client/core/Client.kt
@@ -1,8 +1,8 @@
 package com.laurencegarmstrong.kwamp.client.core
 
+import com.laurencegarmstrong.kwamp.client.core.call.CallHandler
 import com.laurencegarmstrong.kwamp.client.core.call.Callee
 import com.laurencegarmstrong.kwamp.client.core.call.Caller
-import com.laurencegarmstrong.kwamp.client.core.call.CallHandler
 import com.laurencegarmstrong.kwamp.core.*
 import com.laurencegarmstrong.kwamp.core.messages.*
 import com.laurencegarmstrong.kwamp.core.serialization.JsonMessageSerializer
@@ -56,7 +56,10 @@ class Client(
     private fun handleMessage(message: Message) {
         when (message) {
             is Result -> caller.result(message)
+
             is Registered -> callee.receiveRegistered(message)
+            is Unregistered -> callee.receiveUnregistered(message)
+
             is Invocation -> callee.invokeProcedure(message)
 
             is Error -> handleError(message)

--- a/kwamp-client-example/build.gradle.kts
+++ b/kwamp-client-example/build.gradle.kts
@@ -13,13 +13,10 @@ repositories {
 }
 
 val ktorVersion = "0.9.5-rc13"
-val logbackVersion = "1.2.1"
 
 dependencies {
     implementation(project(":kwamp-client-core"))
 
     implementation("io.ktor:ktor-client-websocket:$ktorVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
-
-    implementation("ch.qos.logback:logback-classic:$logbackVersion")
 }

--- a/kwamp-router-example/build.gradle.kts
+++ b/kwamp-router-example/build.gradle.kts
@@ -15,7 +15,6 @@ repositories {
 }
 
 val ktorVersion = "0.9.5-rc13"
-val logbackVersion = "1.2.1"
 
 dependencies {
     implementation(project(":kwamp-router-core"))
@@ -24,6 +23,4 @@ dependencies {
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-websockets:$ktorVersion")
     implementation("io.ktor:ktor-gson:$ktorVersion")
-
-    implementation("ch.qos.logback:logback-classic:$logbackVersion")
 }

--- a/kwamp-router-example/src/main/kotlin/com/laurencegarmstrong/kwamp/router/example/App.kt
+++ b/kwamp-router-example/src/main/kotlin/com/laurencegarmstrong/kwamp/router/example/App.kt
@@ -69,7 +69,6 @@ private suspend fun Application.startWampSession(session: DefaultWebSocketServer
 
         GlobalScope.launch {
             wampOutgoing.consumeEach { message ->
-                log.info("Sending: ${message.toString(Charsets.UTF_8)}")
                 send(Frame.Text(message.toString(Charsets.UTF_8)))
             }
             log.info("Websocket no longer forwarding messages")
@@ -77,7 +76,6 @@ private suspend fun Application.startWampSession(session: DefaultWebSocketServer
 
         incoming.consumeEach { frame ->
             if (frame is Frame.Text && protocol == WAMP_JSON) {
-                log.info("Received: ${frame.readText()}")
                 wampIncoming.send(frame.readText().toByteArray())
             } else if (frame is Frame.Binary && protocol == WAMP_MSG_PACK) {
                 wampIncoming.send(frame.buffer.array())


### PR DESCRIPTION
When client registers a procedure it gets a ```RegistrationHandle```. It can call ```unregister``` on this now and we'll send a message to the router, wait for the reply and then remove the registration.
Also moved logging to to connection level and logged deserialized messages instead of raw ones.